### PR TITLE
do not rely on the startsWith method being available

### DIFF
--- a/src/sibiro/core.cljc
+++ b/src/sibiro/core.cljc
@@ -16,16 +16,17 @@
              :cljs (js/decodeURIComponent))))
 
 (defn- keyword-regex [string start]
-  (let [re-start (.indexOf string "{")
-        re-stop (.indexOf string "}")]
-    (if (<= 0 re-start)
+  (let [re-start (str/index-of string "{")
+        re-stop (str/index-of string "}")]
+    (if (and re-start re-stop)
       [(keyword (subs string start re-start)) (re-pattern (subs string (inc re-start) re-stop))]
       [(keyword (subs string start)) nil])))
 
 (defn- path-parts [path]
-  (map (fn [p] (cond (.startsWith p ":") (keyword-regex p 1)
-                     (.startsWith p "*") (keyword-regex p 0)
-                     :otherwise          p))
+  (map (fn [p] (cond
+                 (str/starts-with? p ":") (keyword-regex p 1)
+                 (str/starts-with? p "*") (keyword-regex p 0)
+                 :otherwise          p))
        (str/split path #"/")))
 
 


### PR DESCRIPTION
use str/starts-with? instead of (.startsWith ...)

startsWith is missing in the JavaFX Webview, which is based on an
embedded webkit engine.

So, let's use the functions in clojure.string.

While I'm here, also use str/index-of instead of .indexOf.